### PR TITLE
Optimize booking participant creation flow

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -20,33 +20,51 @@ class BookingsController < ApplicationController
     @booking = @room.bookings.build(booking_params)
     @booking.user = current_user
 
-    if @booking.save
-      # Create meeting participants using participant_ids from form
-      if params[:participant_ids].present?
-        params[:participant_ids].each do |user_id|
-          user = User.find(user_id)
-          MeetingParticipant.create(
-            user: user,
-            booking: @booking,
-            status: 'pending'
-          )
-        end
-      end
-
-      # Always create a meeting participant for the booking creator
-      MeetingParticipant.create(
-        user: current_user,
-        booking: @booking,
-        status: 'accepted'
-      )
-
-      redirect_to room_booking_path(@room, @booking), notice: 'Booking was successfully created.'
-    else
-      render :new
+    ActiveRecord::Base.transaction do
+      @booking.save!
+      create_meeting_participants!
     end
+
+    redirect_to room_booking_path(@room, @booking), notice: 'Booking was successfully created.'
+  rescue ActiveRecord::RecordInvalid => e
+    @booking.errors.merge!(e.record.errors) if e.record != @booking
+    render :new, status: :unprocessable_entity
+  rescue ActiveRecord::RecordNotFound => e
+    @booking.errors.add(:base, e.message)
+    render :new, status: :unprocessable_entity
   end
 
   private
+
+  def create_meeting_participants!
+    participant_ids = Array(params[:participant_ids]).reject(&:blank?).map(&:to_i).uniq - [current_user.id]
+    users_by_id = User.where(id: participant_ids).index_by(&:id)
+
+    missing_ids = participant_ids - users_by_id.keys
+    raise ActiveRecord::RecordNotFound, "Couldn't find User with IDs: #{missing_ids.join(', ')}" if missing_ids.any?
+
+    timestamp = Time.current
+    participant_rows = users_by_id.values.map do |user|
+      {
+        user_id: user.id,
+        booking_id: @booking.id,
+        status: 'pending',
+        created_at: timestamp,
+        updated_at: timestamp
+      }
+    end
+
+    participant_rows << {
+      user_id: current_user.id,
+      booking_id: @booking.id,
+      status: 'accepted',
+      created_at: timestamp,
+      updated_at: timestamp
+    }
+
+    MeetingParticipant.insert_all!(participant_rows)
+  end
+
 
   def set_room
     @room = if params[:room_id]


### PR DESCRIPTION
### Motivation
- Make booking creation atomic so a failed participant insert does not leave a partial booking in the database. 
- Reduce DB queries and improve scalability by replacing per-participant `find`+`create` loops with a batched insert.

### Description
- Wrap `BookingsController#create` in an `ActiveRecord::Base.transaction` and raise on failures to ensure atomic booking + participants creation. 
- Add a new `create_meeting_participants!` helper that normalizes and deduplicates `participant_ids`, loads users in one query, validates missing IDs, and builds participant rows for a single `MeetingParticipant.insert_all!` call. 
- Exclude the booking creator from pending participants and always insert the creator as `accepted`. 
- Add explicit error handling for `ActiveRecord::RecordInvalid` and `ActiveRecord::RecordNotFound`, merging or adding errors to `@booking` and rendering `:new` with `422 Unprocessable Entity` on failure.

### Testing
- Ran `ruby -c app/controllers/bookings_controller.rb`, which returned `Syntax OK`.
- Attempted `bundle exec rails test`, but the environment lacked the `rails` executable (`bundler: command not found: rails`), so the full test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b69cbb9883328e1b661ab1163a59)